### PR TITLE
Refactor getting_started messages into toolchain

### DIFF
--- a/.bluemix/locales_getting_started.yml
+++ b/.bluemix/locales_getting_started.yml
@@ -1,0 +1,29 @@
+---
+root:
+  $ref: ./nls/messages_getting_started.yml
+de:
+  $ref: ./nls/messages_getting_started_de.yml
+en-AA:
+  $ref: ./nls/messages_getting_started_en_AA.yml
+en-RR:
+  $ref: ./nls/messages_getting_started_en_RR.yml
+en-ZZ:
+  $ref: ./nls/messages_getting_started_en_ZZ.yml
+es:
+  $ref: ./nls/messages_getting_started_es.yml
+fr:
+  $ref: ./nls/messages_getting_started_fr.yml
+it:
+  $ref: ./nls/messages_getting_started_it.yml
+ja:
+  $ref: ./nls/messages_getting_started_ja.yml
+ko:
+  $ref: ./nls/messages_getting_started_ko.yml
+pt-BR:
+  $ref: ./nls/messages_getting_started_pt_BR.yml
+zh:
+  $ref: ./nls/messages_getting_started_zh.yml
+zh-HK:
+  $ref: ./nls/messages_getting_started_zh_HK.yml
+zh-TW:
+  $ref: ./nls/messages_getting_started_zh_TW.yml

--- a/.bluemix/nls/messages.yml
+++ b/.bluemix/nls/messages.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Delivery Insights with IBM UrbanCode Deploy"
 template.description: "Use this toolchain to view deployment metrics from IBM UrbanCode Deploy.\n\nEnable this toolchain to communicate with UrbanCode Deploy by downloading and configuring DevOps Connect from the Settings page in DevOps Insights. Customized instructions explain how to configure DevOps Connect for this toolchain.\n\nAfter data is pushed from UrbanCode Deploy to DevOps Insights,  you can launch DevOps Insights and view the reports on the Delivery Insights dashboard.\n\nTo get started, click **Create**."
-template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Enable this toolchain to communicate with UrbanCode Deploy by downloading and configuring DevOps Connect from the Settings page in DevOps Insights. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights?task=2) for this toolchain."
 headerSVG.deliver: "DELIVER"
 headerSVG.learn: "LEARN"
 headerSVG.urban: "URBAN"

--- a/.bluemix/nls/messages_de.yml
+++ b/.bluemix/nls/messages_de.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Delivery Insights mit IBM UrbanCode Deploy"
 template.description: "Verwenden Sie diese Toolchain, um Messwerte für die Bereitstellung aus IBM UrbanCode Deploy anzuzeigen.\n\nWenn Sie diese Toolchain aktivieren, können Sie mit UrbanCode Deploy kommunizieren, indem Sie DevOps Connect über die Seite 'Einstellungen' in DevOps Insights herunterladen und konfigurieren. Angepasste Anleitungen erläutern, wie Sie DevOps Connect für diese Toolchain konfigurieren.\n\nNachdem Daten aus UrbanCode Deploy in DevOps Insights übertragen wurden,  können Sie DevOps Insights starten und die Berichte im Delivery Insights-Dashboard anzeigen.\n\nKlicken Sie auf **Erstellen**, um zu beginnen."
-template.gettingStarted: "**Ihre Toolchain steht bereit!**\n**Schnelleinstieg:** Aktivieren Sie diese Toolchain, um mit UrbanCode Deploy zu kommunizieren, indem Sie DevOps Connect über die Seite 'Einstellungen' in DevOps Insights herunterladen und konfigurieren. Schrittweise Anleitungen bietet das [Lernprogramm](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) für diese Toolchain."
 headerSVG.deliver: "BEREITSTELLEN"
 headerSVG.learn: "LERNEN"
 headerSVG.urban: "URBAN"

--- a/.bluemix/nls/messages_en_AA.yml
+++ b/.bluemix/nls/messages_en_AA.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "1:Delivery Insights with IBM UrbanCode Deploy"
 template.description: "2:Use this toolchain to view deployment metrics from IBM UrbanCode Deploy.\n\nEnable this toolchain to communicate with UrbanCode Deploy by downloading and configuring DevOps Connect from the Settings page in DevOps Insights. Customized instructions explain how to configure DevOps Connect for this toolchain.\n\nAfter data is pushed from UrbanCode Deploy to DevOps Insights,  you can launch DevOps Insights and view the reports on the Delivery Insights dashboard.\n\nTo get started, click **Create**."
-template.gettingStarted: "3:**Your toolchain is ready!**\n**Quick start:** Enable this toolchain to communicate with UrbanCode Deploy by downloading and configuring DevOps Connect from the Settings page in DevOps Insights. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) for this toolchain."
 headerSVG.deliver: "4:DELIVER"
 headerSVG.learn: "5:LEARN"
 headerSVG.urban: "6:URBAN"

--- a/.bluemix/nls/messages_en_RR.yml
+++ b/.bluemix/nls/messages_en_RR.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Delivery Insights with IBM UrbanCode Deploy~otc-ui595"
 template.description: "Use this toolchain to view deployment metrics from IBM UrbanCode Deploy.\n\nEnable this toolchain to communicate with UrbanCode Deploy by downloading and configuring DevOps Connect from the Settings page in DevOps Insights. Customized instructions explain how to configure DevOps Connect for this toolchain.\n\nAfter data is pushed from UrbanCode Deploy to DevOps Insights,  you can launch DevOps Insights and view the reports on the Delivery Insights dashboard.\n\nTo get started, click **Create**.~otc-ui596"
-template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Enable this toolchain to communicate with UrbanCode Deploy by downloading and configuring DevOps Connect from the Settings page in DevOps Insights. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) for this toolchain.~otc-ui597"
 headerSVG.deliver: "DELIVER~otc-ui598"
 headerSVG.learn: "LEARN~otc-ui599"
 headerSVG.urban: "URBAN~otc-ui600"

--- a/.bluemix/nls/messages_en_ZZ.yml
+++ b/.bluemix/nls/messages_en_ZZ.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "[G'Ｄｅｌｉｖｅｒｙ Ｉｎｓights with IBM UrbanCode Deployฏูİı｜]"
 template.description: "[G'Ｕｓｅ ｔｈｉｓ ｔｏｏｌｃｈａｉｎ ｔｏ ｖｉｅｗ ｄｅｐｌｏｙｍｅｎｔ ｍｅｔｒｉｃｓ ｆｒｏｍ ＩＢＭ ＵｒｂａｎＣｏｄｅ Ｄｅｐｌｏｙ.\n\nＥｎａｂｌｅ ｔｈｉｓ ｔｏｏｌｃｈａｉｎ ｔｏ ｃｏｍｍｕｎｉｃａｔｅ ｗｉｔｈ ＵｒｂａｎＣｏｄｅ Ｄｅｐｌｏｙ ｂｙ ｄｏｗｎｌｏａｄｉｎｇ ａｎｄ ｃｏｎｆｉｇｕｒｉｎg DevOps Connect from the Settings page in DevOps Insights. Customized instructions explain how to configure DevOps Connect for this toolchain.\n\nAfter data is pushed from UrbanCode Deploy to DevOps Insights,  you can launch DevOps Insights and view the reports on the Delivery Insights dashboard.\n\nTo get started, click **Create**.ฏูİı｜]"
-template.gettingStarted: "[G'**Ｙｏｕｒ ｔｏｏｌｃｈａｉｎ ｉｓ ｒｅａｄｙ!**\n**Ｑｕｉｃｋ ｓｔａｒｔ:** Ｅｎａｂｌｅ ｔｈｉｓ ｔｏｏｌｃｈａｉｎ ｔｏ ｃｏｍｍｕｎｉｃａｔｅ ｗｉｔｈ ＵｒｂａｎＣｏｄｅ Ｄｅｐｌｏｙ ｂｙ ｄｏｗｎｌｏａｄｉｎｇ and configuring DevOps Connect from the Settings page in DevOps Insights. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) for this toolchain.ฏูİı｜]"
 headerSVG.deliver: "[G'DELIVERฏูİı｜]"
 headerSVG.learn: "[G'LEARNฏูİı｜]"
 headerSVG.urban: "[G'URBANฏูİı｜]"

--- a/.bluemix/nls/messages_es.yml
+++ b/.bluemix/nls/messages_es.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Delivery Insights con IBM UrbanCode Deploy"
 template.description: "Utilice esta cadena de herramientas para visualizar métricas de despliegue de IBM UrbanCode Deploy. \n\nHabilite esta cadena de herramientas para comunicarse con UrbanCode Deploy mediante la descarga y configuración de DevOps Connect desde la página Valores en DevOps Insights. Las instrucciones personalizadas explican cómo configurar DevOps Connect para esta cadena de herramientas. \n\nDespués de que los datos se hayan enviado desde UrbanCode Deploy a DevOps Insights, podrá iniciar DevOps Insights y visualizar los informes en el panel de control de Delivery Insights. \n\nPara comenzar, pulse **Crear**."
-template.gettingStarted: "**¡Su cadena de herramientas está lista!**\n**Inicio rápido:** Habilite esta cadena de herramientas para comunicarse con UrbanCode Deploy mediante la descarga y configuración de DevOps Connect desde la página Valores en DevOps Insights. Para obtener instrucciones detalladas paso a paso, consulte la [guía de aprendizaje](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) para esta cadena de herramientas. "
 headerSVG.deliver: "ENTREGAR"
 headerSVG.learn: "APRENDER"
 headerSVG.urban: "URBAN"

--- a/.bluemix/nls/messages_fr.yml
+++ b/.bluemix/nls/messages_fr.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Delivery Insights avec IBM UrbanCode Deploy"
 template.description: "Cette chaîne d'outils permet de visualiser les mesures de déploiement d'IBM UrbanCode Deploy.\n\nActivez cette chaîne d'outils afin qu'elle communique avec UrbanCode Deploy en téléchargeant et en configurant DevOps Connect à partir de la page Settings de DevOps Insights. Des instructions personnalisées vous expliquent comment configurer DevOps Connect pour cette chaîne d'outils.\n\nUne fois les données envoyées par notification push depuis UrbanCode Deploy vers DevOps Insights, vous pouvez lancer DevOps Insights et afficher les rapports sur le tableau de bord Delivery Insights. \n\nPour commencer, cliquez sur **Créer**."
-template.gettingStarted: "**Votre chaîne d'outils est prête !**\n**Démarrage rapide :** activez cette chaîne d'outils afin qu'elle communique avec UrbanCode Deploy en téléchargeant et en configurant DevOps Connect à partir de la page Settings de DevOps Insights. Pour obtenir des instructions étape par étape, reportez-vous au [tutoriel](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) relatif à cette chaîne d'outils. "
 headerSVG.deliver: "DISTRIBUER"
 headerSVG.learn: "APPRENDRE"
 headerSVG.urban: "URBAN"

--- a/.bluemix/nls/messages_getting_started.yml
+++ b/.bluemix/nls/messages_getting_started.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Enable this toolchain to communicate with UrbanCode Deploy by downloading and configuring DevOps Connect from the Settings page in DevOps Insights. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights?task=2) for this toolchain."

--- a/.bluemix/nls/messages_getting_started_de.yml
+++ b/.bluemix/nls/messages_getting_started_de.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Ihre Toolchain steht bereit!**\n**Schnelleinstieg:** Aktivieren Sie diese Toolchain, um mit UrbanCode Deploy zu kommunizieren, indem Sie DevOps Connect über die Seite 'Einstellungen' in DevOps Insights herunterladen und konfigurieren. Schrittweise Anleitungen bietet das [Lernprogramm](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) für diese Toolchain."

--- a/.bluemix/nls/messages_getting_started_en_AA.yml
+++ b/.bluemix/nls/messages_getting_started_en_AA.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "3:**Your toolchain is ready!**\n**Quick start:** Enable this toolchain to communicate with UrbanCode Deploy by downloading and configuring DevOps Connect from the Settings page in DevOps Insights. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) for this toolchain."

--- a/.bluemix/nls/messages_getting_started_en_RR.yml
+++ b/.bluemix/nls/messages_getting_started_en_RR.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Enable this toolchain to communicate with UrbanCode Deploy by downloading and configuring DevOps Connect from the Settings page in DevOps Insights. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) for this toolchain.~otc-ui597"

--- a/.bluemix/nls/messages_getting_started_en_ZZ.yml
+++ b/.bluemix/nls/messages_getting_started_en_ZZ.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "[G'**Ｙｏｕｒ ｔｏｏｌｃｈａｉｎ ｉｓ ｒｅａｄｙ!**\n**Ｑｕｉｃｋ ｓｔａｒｔ:** Ｅｎａｂｌｅ ｔｈｉｓ ｔｏｏｌｃｈａｉｎ ｔｏ ｃｏｍｍｕｎｉｃａｔｅ ｗｉｔｈ ＵｒｂａｎＣｏｄｅ Ｄｅｐｌｏｙ ｂｙ ｄｏｗｎｌｏａｄｉｎｇ and configuring DevOps Connect from the Settings page in DevOps Insights. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) for this toolchain.ฏูİı｜]"

--- a/.bluemix/nls/messages_getting_started_es.yml
+++ b/.bluemix/nls/messages_getting_started_es.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**¡Su cadena de herramientas está lista!**\n**Inicio rápido:** Habilite esta cadena de herramientas para comunicarse con UrbanCode Deploy mediante la descarga y configuración de DevOps Connect desde la página Valores en DevOps Insights. Para obtener instrucciones detalladas paso a paso, consulte la [guía de aprendizaje](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) para esta cadena de herramientas. "

--- a/.bluemix/nls/messages_getting_started_fr.yml
+++ b/.bluemix/nls/messages_getting_started_fr.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Votre chaîne d'outils est prête !**\n**Démarrage rapide :** activez cette chaîne d'outils afin qu'elle communique avec UrbanCode Deploy en téléchargeant et en configurant DevOps Connect à partir de la page Settings de DevOps Insights. Pour obtenir des instructions étape par étape, reportez-vous au [tutoriel](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) relatif à cette chaîne d'outils. "

--- a/.bluemix/nls/messages_getting_started_it.yml
+++ b/.bluemix/nls/messages_getting_started_it.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**La toolchain è pronta!**\n**Avvio rapido:** Abilitare questa toolchain per comunicare con UrbanCode Deploy scaricando e configurando DevOps Connect dalla pagina Impostazioni in DevOps Insights. Per le istruzioni passo dopo passo, consultare il [supporto didattico](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) per questa toolchain."

--- a/.bluemix/nls/messages_getting_started_ja.yml
+++ b/.bluemix/nls/messages_getting_started_ja.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**ツールチェーンの準備ができました。**\n**クイック・スタート:** このツールチェーンが UrbanCode Deploy と通信できるようにするには、DevOps Connect をダウンロードして DevOps Insights の「設定」ページで構成します。ステップバイステップの説明については、このツールチェーンの[チュートリアル](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights)を参照してください。"

--- a/.bluemix/nls/messages_getting_started_ko.yml
+++ b/.bluemix/nls/messages_getting_started_ko.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**도구 체인이 준비되었습니다!**\n**빠른 시작:** DevOps Insights의 설정 페이지에서 DevOps Connect를 다운로드하고 구성하여 이 도구 체인에서 UrbanCode Deploy와 통신할 수 있습니다. 단계별 지시사항은 이 도구 체인의 [튜토리얼](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights)을 참조하십시오."

--- a/.bluemix/nls/messages_getting_started_pt_BR.yml
+++ b/.bluemix/nls/messages_getting_started_pt_BR.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Sua cadeia de ferramentas está pronta!**\n**Iniciação rápida:** Ative essa cadeia de ferramentas para se comunicar com o UrbanCode Deploy fazendo download e configurando o DevOps Connect na página Configurações do DevOps Insights. Para obter instruções passo a passo, consulte o [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) para essa cadeia de ferramentas."

--- a/.bluemix/nls/messages_getting_started_zh.yml
+++ b/.bluemix/nls/messages_getting_started_zh.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**工具链已就绪！**\n**快速启动：** 启用此工具链可通过从 DevOps Insights 中的“设置”页面下载并配置 DevOps Connect，与 UrbanCode Deploy 进行通信。有关逐步指示信息，请参阅此工具链的[教程](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights)。"

--- a/.bluemix/nls/messages_getting_started_zh_HK.yml
+++ b/.bluemix/nls/messages_getting_started_zh_HK.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 啟用此工具鏈與 UrbanCode Deploy 通訊，方法為從 DevOps Insights 中的「設定」頁面下載並配置 DevOps Connect。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights)。"

--- a/.bluemix/nls/messages_getting_started_zh_TW.yml
+++ b/.bluemix/nls/messages_getting_started_zh_TW.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 啟用此工具鏈與 UrbanCode Deploy 通訊，方法為從 DevOps Insights 中的「設定」頁面下載並配置 DevOps Connect。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights)。"

--- a/.bluemix/nls/messages_it.yml
+++ b/.bluemix/nls/messages_it.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Delivery Insights con IBM UrbanCode Deploy"
 template.description: "Utilizzare questa toolchain per visualizzare le metriche di distribuzione da IBM UrbanCode Deploy.\n\nAbilitare questa toolchain per comunicare con UrbanCode Deploy scaricando e configurando DevOps Connect dalla pagina Impostazioni in DevOps Insights.Istruzioni personalizzate descrivono in che modo configurare DevOps Connect per questa toolchain.\n\nUna volta che vengono immessi i dati richiesti da UrbanCode Deploy in DevOps Insights,  è possibile avviare DevOps Insights e visualizzare i report sul dashboard Delivery Insights.\n\nPer iniziare, fare clic su **Crea**."
-template.gettingStarted: "**La toolchain è pronta!**\n**Avvio rapido:** Abilitare questa toolchain per comunicare con UrbanCode Deploy scaricando e configurando DevOps Connect dalla pagina Impostazioni in DevOps Insights. Per le istruzioni passo dopo passo, consultare il [supporto didattico](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) per questa toolchain."
 headerSVG.deliver: "DISTRIBUISCI"
 headerSVG.learn: "IMPARA"
 headerSVG.urban: "URBAN"

--- a/.bluemix/nls/messages_ja.yml
+++ b/.bluemix/nls/messages_ja.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Delivery Insights (IBM UrbanCode Deploy)"
 template.description: "このツールチェーンは、IBM UrbanCode Deploy からデプロイメント・メトリックを表示する場合に使用します。\n\nこのツールチェーンが UrbanCode Deploy と通信できるようにするには、DevOps Connect をダウンロードして DevOps Insights の「設定」ページで構成します。このツールチェーン用に DevOps Connect を構成する方法が、カスタマイズされた説明によって示されます。\n\nUrbanCode Deploy から DevOps Insights にデータがプッシュされた後で DevOps Insights を起動して Delivery Insights ダッシュボード上にレポートを表示できます。\n\n開始するには、**「作成」**をクリックします。"
-template.gettingStarted: "**ツールチェーンの準備ができました。**\n**クイック・スタート:** このツールチェーンが UrbanCode Deploy と通信できるようにするには、DevOps Connect をダウンロードして DevOps Insights の「設定」ページで構成します。ステップバイステップの説明については、このツールチェーンの[チュートリアル](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights)を参照してください。"
 headerSVG.deliver: "配信"
 headerSVG.learn: "学習"
 headerSVG.urban: "URBAN"

--- a/.bluemix/nls/messages_ko.yml
+++ b/.bluemix/nls/messages_ko.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "IBM UrbanCode Deploy를 사용하는 Delivery Insights"
 template.description: "이 도구 체인을 사용하여 IBM UrbanCode Deploy에서 배치 메트릭을 봅니다.\n\nDevOps Insights의 설정 페이지에서 DevOps Connect를 다운로드하고 구성하여 이 도구 체인에서 UrbanCode Deploy와 통신합니다. 사용자 정의 지시사항은 이 도구 체인에 맞게 DevOps Connect를 구성하는 방법을 설명합니다.\n\nUrbanCode Deploy에서 DevOps Insights로 데이터를 푸시하고 나면 DevOps Insights를 시작하고 Delivery Insights 대시보드에서 보고서를 볼 수 있습니다.\n\n계속하려면 **작성**을 클릭하십시오."
-template.gettingStarted: "**도구 체인이 준비되었습니다!**\n**빠른 시작:** DevOps Insights의 설정 페이지에서 DevOps Connect를 다운로드하고 구성하여 이 도구 체인에서 UrbanCode Deploy와 통신할 수 있습니다. 단계별 지시사항은 이 도구 체인의 [튜토리얼](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights)을 참조하십시오."
 headerSVG.deliver: "전달"
 headerSVG.learn: "학습"
 headerSVG.urban: "URBAN"

--- a/.bluemix/nls/messages_pt_BR.yml
+++ b/.bluemix/nls/messages_pt_BR.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Entregue insights com o IBM UrbanCode Deploy"
 template.description: "Use essa cadeia de ferramentas para visualizar métricas de implementação do IBM UrbanCode Deploy.\n\nAtive essa cadeia de ferramentas para se comunicar com o UrbanCode Deploy fazendo download e configurando o DevOps Connect na página Configurações do DevOps Insights. Instruções customizadas explicam como configurar o DevOps Connect para essa cadeia de ferramentas.\n\nDepois que os dados são enviados por push do UrbanCode Deploy para o DevOps Insights, é possível iniciar o DevOps Insights e visualizar os relatórios no painel Entregar insights.\n\nPara iniciar, clique em **Criar**."
-template.gettingStarted: "**Sua cadeia de ferramentas está pronta!**\n**Iniciação rápida:** Ative essa cadeia de ferramentas para se comunicar com o UrbanCode Deploy fazendo download e configurando o DevOps Connect na página Configurações do DevOps Insights. Para obter instruções passo a passo, consulte o [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights) para essa cadeia de ferramentas."
 headerSVG.deliver: "DELIVER"
 headerSVG.learn: "APRENDER"
 headerSVG.urban: "URBAN"

--- a/.bluemix/nls/messages_zh.yml
+++ b/.bluemix/nls/messages_zh.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "使用 IBM UrbanCode Deploy 的 Delivery Insights"
 template.description: "使用此工具链可查看 IBM UrbanCode Deploy 中的部署度量值。\n\n启用此工具链可通过从 DevOps Insights 中的“设置”页面下载并配置 DevOps Connect，与 UrbanCode Deploy 进行通信。定制指示信息说明了如何为此工具链配置 DevOps Connect。\n\n将数据从 UrbanCode Deploy 推送到 DevOps Insights 后，可以启动 DevOps Insights，并在 Delivery Insights 仪表板上查看报告。\n\n单击**创建**以开始。"
-template.gettingStarted: "**工具链已就绪！**\n**快速启动：** 启用此工具链可通过从 DevOps Insights 中的“设置”页面下载并配置 DevOps Connect，与 UrbanCode Deploy 进行通信。有关逐步指示信息，请参阅此工具链的[教程](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights)。"
 headerSVG.deliver: "交付"
 headerSVG.learn: "了解"
 headerSVG.urban: "URBAN"

--- a/.bluemix/nls/messages_zh_HK.yml
+++ b/.bluemix/nls/messages_zh_HK.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "搭配 IBM UrbanCode Deploy 的 Delivery Insights"
 template.description: "使用此工具鏈，可從 IBM UrbanCode Deploy 檢視部署度量值。\n\n啟用此工具鏈與 UrbanCode Deploy 通訊，方法為從 DevOps Insights 中的「設定」頁面下載並配置 DevOps Connect。自訂指示說明如何對此工具鏈配置 DevOps Connect。\n\n將 UrbanCode Deploy 中的資料推送至 DevOps Insights 之後，您可以啟動 DevOps Insights，並在 Delivery Insights 儀表板上檢視報告。\n\n若要開始，請按一下**建立**。"
-template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 啟用此工具鏈與 UrbanCode Deploy 通訊，方法為從 DevOps Insights 中的「設定」頁面下載並配置 DevOps Connect。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights)。"
 headerSVG.deliver: "交付"
 headerSVG.learn: "學習"
 headerSVG.urban: "URBAN"

--- a/.bluemix/nls/messages_zh_TW.yml
+++ b/.bluemix/nls/messages_zh_TW.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "搭配 IBM UrbanCode Deploy 的 Delivery Insights"
 template.description: "使用此工具鏈，可從 IBM UrbanCode Deploy 檢視部署度量值。\n\n啟用此工具鏈與 UrbanCode Deploy 通訊，方法為從 DevOps Insights 中的「設定」頁面下載並配置 DevOps Connect。自訂指示說明如何對此工具鏈配置 DevOps Connect。\n\n將 UrbanCode Deploy 中的資料推送至 DevOps Insights 之後，您可以啟動 DevOps Insights，並在 Delivery Insights 儀表板上檢視報告。\n\n若要開始，請按一下**建立**。"
-template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 啟用此工具鏈與 UrbanCode Deploy 通訊，方法為從 DevOps Insights 中的「設定」頁面下載並配置 DevOps Connect。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_delivery_insights)。"
 headerSVG.deliver: "交付"
 headerSVG.learn: "學習"
 headerSVG.urban: "URBAN"

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -17,7 +17,7 @@ toolchain:
     name: 'deliveryinsights-toolchain-{{timestamp}}'
     template:
         getting_started:
-            $ref: "#/messages/template.gettingStarted"   
+            $ref: locales_getting_started.yml   
 services:
     dra:
       service_id: draservicebroker


### PR DESCRIPTION
Store all translations of 'getting started' message in the `toolchain.template` field.
This allows the UI to choose which string to display according to the browser locale.